### PR TITLE
Make the GameManager class act like a singleton

### DIFF
--- a/src/gamemanager.js
+++ b/src/gamemanager.js
@@ -1,5 +1,7 @@
 import Model from './model';
 
+const manager = new GameManager();
+
 class GameManager {
   constructor() {
     this.modelList = [];
@@ -33,8 +35,4 @@ class GameManager {
   }
 }
 
-const manager = new GameManager();
-
-export default manager;
-
-export {GameManager};
+export {manager as default, GameManager};

--- a/src/gamemanager.js
+++ b/src/gamemanager.js
@@ -33,4 +33,8 @@ class GameManager {
   }
 }
 
-export default GameManager;
+const manager = new GameManager();
+
+export default manager;
+
+export {GameManager};

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import GameObject from './game-object';
 import Physics from './physics';
 import { gl } from './constants';
 import { Vector3 } from 'three';
-import GameManager from './gamemanager';
+import manager from './gamemanager';
 import { deg2rad } from './utils/math';
 
 const m4 = twgl.m4;
@@ -34,8 +34,6 @@ const main = async () => {
 
   // track when the last frame rendered
   let lastFrameMilis = 0;
-
-  const manager = new GameManager();
 
   const modelRefs = [
     require('./models/raymanModel.obj'),


### PR DESCRIPTION
## Justification:
The states and values of the game manager are needed in files other than `index.js`. By creating only one instance of the game manager class, we can reference the same scene objects project-wide. This does not affect the ability to load models, as that is still handled in `index.js`. The inclusion of other files that reference the manager before the call to `manager.addModels()` ***should not*** break any functionality.

### Warning:
As mentioned in the last sentence of Justification, other files that include the manager and reference it should not break any functionality. This is a requirement. Any file that include the manager must not preform any destructive acts on the manager unless that act occurs in a function called from `index.js`. A destructive act is any act that can hinder expected behavior from the manager, including but not limited to the ability to load and reference a model list, and the ability to load and reference a list of scene objects.