### PR TITLE
Change model loading and indexing to use a name

### DIFF
--- a/src/gamemanager.js
+++ b/src/gamemanager.js
@@ -8,10 +8,11 @@ class GameManager {
   }
 
   async addModels(models) {
-    for (const url of models) {
+    for (const model of models) {
+      const url = model.model;
       const m = new Model();
       await m.load(url);
-      this.modelList.push(m);
+      this.modelList[model.name] = m;
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,18 +36,21 @@ const main = async () => {
   // track when the last frame rendered
   let lastFrameMilis = 0;
 
-  const modelRefs = [require('./models/raymanModel.obj'), require('./models/cow.obj')];
+  const modelRefs = [
+    { model: require('./models/raymanModel.obj'), name: 'rayman' }, 
+    { model: require('./models/cow.obj'), name: 'cow' }
+  ];
 
   await manager.addModels(modelRefs);
 
-  const myRayman = new GameObject(manager.modelList[0], new Physics());
-  const myCow = new GameObject(manager.modelList[1], new Physics());
+  const myRayman = new GameObject(manager.modelList['rayman'], new Physics());
+  const myCow = new GameObject(manager.modelList['cow'], new Physics());
 
   manager.addObjects([myRayman, myCow]);
 
   myCow.physics.angularVelocity = new Vector3(10, 10, 10);
 
-  const raymanModelExtents = manager.modelList[0].getModelExtent();
+  const raymanModelExtents = manager.modelList['rayman'].getModelExtent();
 
   // camera begin
   const eye = m4.transformPoint(m4.multiply(m4.translation(raymanModelExtents.center), m4.multiply(m4.rotationY(0), m4.rotationX(0))), [

--- a/src/index.js
+++ b/src/index.js
@@ -37,20 +37,20 @@ const main = async () => {
   let lastFrameMilis = 0;
 
   const modelRefs = [
-    { model: require('./models/raymanModel.obj'), name: 'rayman' }, 
+    { model: require('./models/raymanModel.obj'), name: 'rayman' },
     { model: require('./models/cow.obj'), name: 'cow' }
   ];
 
   await manager.addModels(modelRefs);
 
-  const myRayman = new GameObject(manager.modelList['rayman'], new Physics());
-  const myCow = new GameObject(manager.modelList['cow'], new Physics());
+  const myRayman = new GameObject(manager.modelList.rayman, new Physics());
+  const myCow = new GameObject(manager.modelList.cow, new Physics());
 
   manager.addObjects([myRayman, myCow]);
 
   myCow.physics.angularVelocity = new Vector3(10, 10, 10);
 
-  const raymanModelExtents = manager.modelList['rayman'].getModelExtent();
+  const raymanModelExtents = manager.modelList.rayman.getModelExtent();
 
   // camera begin
   const eye = m4.transformPoint(m4.multiply(m4.translation(raymanModelExtents.center), m4.multiply(m4.rotationY(0), m4.rotationX(0))), [


### PR DESCRIPTION
Makes `manager.modelList` accessible by a common model name rather than an arbitrary index. Fixes #10.