### PR TITLE
Cleanup index and add resize tracking

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -30,7 +30,14 @@ class Camera {
    * @param {{ x: number, y: number, z: number }} lookAt
    */
   lookAt(lookAt) {
-    this.lookAtTarget.set(lookAt.x, lookAt.y, lookAt.z);
+    const { x, y, z } = this.lookAtTarget
+
+    this.lookAtTarget.set(
+      lookAt.x ?? x,
+      lookAt.y ?? y,
+      lookAt.z ?? z
+    );
+
     this.updateViewMatrix();
   }
 
@@ -46,7 +53,13 @@ class Camera {
    * @param {{ x: number, y: number, z: number }} position
    */
   setPosition(position) {
-    this.position.set(position.x, position.y, position.z);
+    const { x, y, z } = this.position
+    
+    this.position.set(
+      position.x ?? x,
+      position.y ?? y,
+      position.z ?? z
+    );
 
     this.updateViewMatrix();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,11 @@ const main = async () => {
     // calculate the change in time in seconds since the last frame
     let deltaTime = (curentMilis - lastFrameMilis) / 1000;
 
+    // check if the canvas needs to be resized, if so, things need to be recreated here
+    if (wasResized) {
+      // re create frame buffers (TODO) here so that they have the proper settings
+    }
+
     // update things here
     update(deltaTime);
 
@@ -95,9 +100,20 @@ const main = async () => {
     );
   }
 
-  // this is going to get changed next commit
-  gl.viewport(0, 0, window.innerWidth, window.innerHeight);
+  // track if the window was resized and adjust the canvas and viewport to match
+  let wasResized = false;
+  window.addEventListener('resize', () => {
+    // even though this is an event listener, due to the nature of the javascript event loop, 
+    // this will not cause weird timing issues with our rendering because we cant be rendering and processing this at the same time
+    // it just inst possible
+    twgl.resizeCanvasToDisplaySize(gl.canvas);
+    gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+    wasResized = true;
+  });
+
+  // this will make init the canvas width and height and the viewport
   twgl.resizeCanvasToDisplaySize(gl.canvas);
+  gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
 
   // start the render loop by requesting an animation frame for the frame function
   rafHandle = requestAnimationFrame(frame);

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import { Vector3 } from 'three';
 const main = async () => {
   const programInfo = twgl.createProgramInfo(gl, [vs, fs], error => console.log(error));
 
-  // // init gl stuff here, like back face culling and the depth test
+  // init gl stuff here, like back face culling and the depth test
   gl.enable(gl.DEPTH_TEST);
   gl.clearColor(0.5, 0.2, 0.7, 1.0);
 
@@ -42,22 +42,20 @@ const main = async () => {
   const ufo = new GameObject(manager.modelList.ufo, ufoPhysics);
   const myAsteroid1 = new GameObject(manager.modelList.asteroid0, asteroidPhysics);
 
-  const raymanModelExtents = manager.modelList.rayman.getModelExtent();
-
-  const camera = new Camera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-  // Add models to canvas
+  // Add testing models to canvas
   manager.addObject(myAsteroid1);
   manager.addObject(ufo);
-
-  /** mainModel should be the main model of the scene */
+  
+  // mainModel should be the 'main' model of the scene
   const mainModel = manager.modelList.ufo.getModelExtent();
 
+  // create and init camera
+  const camera = new Camera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
   camera.lookAt({
     x: 0,
     y: 0,
     z: 0
   });
-
   camera.setPosition({
     x: mainModel.dia * 0, 
     y: mainModel.dia * 0.7,
@@ -85,16 +83,19 @@ const main = async () => {
     lastFrameMilis = curentMilis;
   }
 
+  // update function, responsible for updating all objects and things that need to be updated since last frame
   function update(deltaTime) {
     manager.sceneObjects.forEach(sceneObject => sceneObject.update(deltaTime));
   }
 
+  // render function, responsible for all rendering, including shadows (TODO), model rendering, and post processing (TODO)
   function render(deltaTime) {
     manager.sceneObjects.forEach(sceneObject =>
       sceneObject.render(programInfo, camera.getUniforms())
     );
   }
 
+  // this is going to get changed next commit
   gl.viewport(0, 0, window.innerWidth, window.innerHeight);
   twgl.resizeCanvasToDisplaySize(gl.canvas);
 


### PR DESCRIPTION
# Justification:
- cleanup index
  - some comments were missing from index and it could have been organized better
- resize tracking
  - post-processing frame buffers (future feature) need to have the proper size of the window at all times to properly blit to the screen and take the multi sample properly
  - If the screen is created small then enlarged, the enlarged version will show up blury and unfocused (see exaggerated screen shots 1 and 2)

### Screen shot 1
The page was refreshed with the window this small. It is a very small window, and while a user is unlikely to start their window this small, it serves to show the problem solved by resize tracking.
![image](https://user-images.githubusercontent.com/17838365/142962021-9fae7dca-e286-409d-a980-8bb8b6677ed2.png)

### Screen shot 2
Once the window has been maximized or enlarged, the resulting image becomes very blurry and unfocused due to the canvas not being resized. Again, this is an exaggeration but it is possible to happen.
![image](https://user-images.githubusercontent.com/17838365/142962269-079eb137-4ebf-4204-a699-c82fb2cf8e6f.png)

