### PR TITLE
Collisions + asteroid scale increase

### DIFF
--- a/src/game-object.js
+++ b/src/game-object.js
@@ -96,6 +96,15 @@ class GameObject {
       z: this.position.z + (z ?? 0)
     };
   }
+
+  /**
+   * @typedef {import('./game-object').default} GameObject
+   * @param {GameObject} gameobject
+   * Add a already created gameobject to the manager
+   */
+  doesCollide(gameobject) {
+    return this.position.distanceTo(gameobject.position) <= this.physics.colliderRadius + gameobject.colliderRadius;
+  }
 }
 
 export default GameObject;

--- a/src/game-object.js
+++ b/src/game-object.js
@@ -24,12 +24,16 @@ class GameObject {
     this.scale = 1;
     this.rotation = new Vector3();
     this.position = new Vector3();
+
+    this.physics.colliderRadius = (this.model.extents.dia / 2) * this.scale;
   }
 
   update(deltaTime) {
     // Physics update
     this.position.add(this.physics.velocity.clone().multiplyScalar(deltaTime));
     this.rotation.add(this.physics.angularVelocity.clone().multiplyScalar(deltaTime));
+    this.physics.colliderRadius = (this.model.extents.dia / 2) * this.scale;
+
     this.computeModelMatrix();
   }
 
@@ -100,10 +104,12 @@ class GameObject {
   /**
    * @typedef {import('./game-object').default} GameObject
    * @param {GameObject} gameobject
-   * Add a already created gameobject to the manager
+   * gameobject to check collision with
    */
   doesCollide(gameobject) {
-    return this.position.distanceTo(gameobject.position) <= this.physics.colliderRadius + gameobject.colliderRadius;
+    const dist = this.position.distanceTo(gameobject.position);
+    const sumRadi = this.physics.colliderRadius + gameobject.physics.colliderRadius;
+    return dist <= sumRadi;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,13 @@ const main = async () => {
     // Update the position of each object
     manager.sceneObjects.forEach(sceneObject => sceneObject.update(deltaTime));
 
+    // check for UFO colliding with anything
+    for (const gameobject of manager.sceneObjects) {
+      // avoid colliding with self
+      if (gameobject == ufo) continue;
+      if (ufo.doesCollide(gameobject)) console.log('UFO collided with asteroid!');
+    }
+
     // Fix the camera so it's positioned behind the ship each frame
     let offset = new Vector3(0, mainModel.dia * 0.5, mainModel.dia);
     camera.setPosition(ufo.position.clone().add(offset));

--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,6 @@ const main = async () => {
   const ufo = new GameObject(manager.modelList.ufo, ufoPhysics);
   const myAsteroid1 = new GameObject(manager.modelList.asteroid0, asteroidPhysics);
 
-  const raymanModelExtents = manager.modelList.rayman.getModelExtent();
-
   const camera = new Camera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
   // Add models to canvas
   manager.addObject(myAsteroid1);
@@ -59,7 +57,7 @@ const main = async () => {
   });
 
   camera.setPosition({
-    x: mainModel.dia * 0, 
+    x: mainModel.dia * 0,
     y: mainModel.dia * 0.7,
     z: mainModel.dia
   });
@@ -90,9 +88,7 @@ const main = async () => {
   }
 
   function render(deltaTime) {
-    manager.sceneObjects.forEach(sceneObject =>
-      sceneObject.render(programInfo, camera.getUniforms())
-    );
+    manager.sceneObjects.forEach(sceneObject => sceneObject.render(programInfo, camera.getUniforms()));
   }
 
   gl.viewport(0, 0, window.innerWidth, window.innerHeight);

--- a/src/model.js
+++ b/src/model.js
@@ -95,6 +95,7 @@ class Model {
      * Same as sceneBufferInfoArray from the professor's observable
      */
     this.vertexAttributes = [];
+    this.extents = {};
   }
 
   load(modelURL) {
@@ -124,6 +125,7 @@ class Model {
     }));
 
     this.vertexAttributes = va.map(attribute => twgl.createBufferInfoFromArrays(gl, attribute));
+    this.extents = this.getModelExtent();
   }
 
   render(programInfo, uniforms) {

--- a/src/utils/object-selector.js
+++ b/src/utils/object-selector.js
@@ -5,72 +5,69 @@ import { getRandomDir, getRandomInt } from './math';
 import { Vector3 } from 'three';
 
 class ObjectSelector extends GameObject {
-    constructor(objectNumber = 0) {
-        
-        // Object selector
-        switch (objectNumber) {
-            case 0:
-                super(manager.modelList.asteroid0, new Physics());
-                this.scaleAmount = 20.0;
-                this.shouldRotate = true;
-                this.shouldMove = true;
-                this.velScalar = 20;
-                break;
-            case 1:
-                super(manager.modelList.asteroid1, new Physics());
-                this.scaleAmount = 0.5;
-                this.shouldRotate = true;
-                this.shouldMove = true;
-                this.velScalar = 20;
-                break;
-            // case 2:
-                // Add a power up object that increases speed?
-            default:
-                console.error("Object number passed into the ObjectSelector is invalid.")
-                break;
-        }
-
-        // Member variables
-        this.initWithRandom(true);
-        this.ufoDia = manager.ufo.initalDia;
+  constructor(objectNumber = 0) {
+    // Object selector
+    switch (objectNumber) {
+      case 0:
+        super(manager.modelList.asteroid0, new Physics());
+        this.scaleAmount = 20.0;
+        this.shouldRotate = true;
+        this.shouldMove = true;
+        this.velScalar = 20;
+        break;
+      case 1:
+        super(manager.modelList.asteroid1, new Physics());
+        this.scaleAmount = 0.5;
+        this.shouldRotate = true;
+        this.shouldMove = true;
+        this.velScalar = 20;
+        break;
+      // case 2:
+      // Add a power up object that increases speed?
+      default:
+        console.error('Object number passed into the ObjectSelector is invalid.');
+        break;
     }
 
-    update(deltaTime) {
-        // check here for out of bounds, update position
-        if (manager.ufo.position.z < this.position.z - this.ufoDia) {
-            this.initWithRandom(false);
-        }
+    // Member variables
+    this.initWithRandom(true);
+    this.ufoDia = manager.ufo.initalDia;
+  }
 
-        // you want to call this btw
-        super.update(deltaTime);
+  update(deltaTime) {
+    // check here for out of bounds, update position
+    if (manager.ufo.position.z < this.position.z - this.ufoDia) {
+      this.initWithRandom(false);
     }
-    initWithRandom(flag) {
-        let x = getRandomInt(manager.box.xMin, manager.box.xMax);
-        let y = getRandomInt(manager.box.yMin, manager.box.yMax);
-        let z;
-        if (flag) 
-            z = getRandomInt(manager.ufo.position.z + manager.box.zMin, manager.ufo.position.z + manager.box.zMax);
-        else 
-            z = getRandomInt(manager.ufo.position.z + manager.box.zMin - 1000, manager.ufo.position.z + manager.box.zMax);
 
-        this.position = new Vector3(x, y, z);
+    // you want to call this btw
+    super.update(deltaTime);
+  }
+  initWithRandom(flag) {
+    let x = getRandomInt(manager.box.xMin, manager.box.xMax);
+    let y = getRandomInt(manager.box.yMin, manager.box.yMax);
+    let z;
+    if (flag) z = getRandomInt(manager.ufo.position.z + manager.box.zMin, manager.ufo.position.z + manager.box.zMax);
+    else z = getRandomInt(manager.ufo.position.z + manager.box.zMin - 1000, manager.ufo.position.z + manager.box.zMax);
 
-        let vel;
-        if (this.shouldMove) {
-            vel = new Vector3(getRandomDir() * this.velScalar, getRandomDir() * this.velScalar, getRandomDir() * this.velScalar);
-        } else {
-            vel = new Vector3(0, 0, 0);
-        }
-        this.physics.velocity = vel;
-        
-        if (this.shouldRotate) {
-            const rot = new Vector3(getRandomDir(), getRandomDir(), getRandomDir());
-            rot.multiplyScalar(Math.random() * 80);
-            this.physics.angularVelocity = rot;
-        }
-        
-        this.scale = Math.random() * this.scaleAmount;
+    this.position = new Vector3(x, y, z);
+
+    let vel;
+    if (this.shouldMove) {
+      vel = new Vector3(getRandomDir() * this.velScalar, getRandomDir() * this.velScalar, getRandomDir() * this.velScalar);
+    } else {
+      vel = new Vector3(0, 0, 0);
     }
+    this.physics.velocity = vel;
+
+    if (this.shouldRotate) {
+      const rot = new Vector3(getRandomDir(), getRandomDir(), getRandomDir());
+      rot.multiplyScalar(Math.random() * 80);
+      this.physics.angularVelocity = rot;
+    }
+
+    this.scale = (Math.random() + 0.5) * this.scaleAmount;
+  }
 }
 
 export default ObjectSelector;


### PR DESCRIPTION
Adds minimal framework for collisions. Fixes #22 
- Collider radius calculated based on model extents and Gameobject scale
- `doesCollide` function to check if two gameobjects are colliding
- Collision pass in `index.js` to check **if UFO collides with other objects** (collision pass does NOT check other objects amongst themselves. We can add it later on for spaceship projectiles, for instance.)

Also shifted up the range of random scales for the asteroids as they were able to get far too small / not big enough.